### PR TITLE
Add Rake as development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.3)
+    rake (10.1.0)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -21,4 +22,5 @@ PLATFORMS
 
 DEPENDENCIES
   mt940!
+  rake
   rspec

--- a/mt940.gemspec
+++ b/mt940.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'mt940'
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rake'
   
   s.files         = `git ls-files`.split(/\n/)
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split(/\n/)


### PR DESCRIPTION
The README notes to run tests with `bundle exec rake spec`, which actually fails unless you add Rake to the gemspec as a development dependency.
