### PR TITLE
Handle 7 or 8 digit bank account numbers

### DIFF
--- a/lib/mt940/banks/rabobank.rb
+++ b/lib/mt940/banks/rabobank.rb
@@ -21,7 +21,7 @@ class MT940::Rabobank < MT940::Base
                                             date: valuta_date,
                                             contra_account_iban: contra_account_iban,
                                             contra_account: number)
-    elsif @line.match(/^:61:(\d{6})(C|D)(\d+),(\d{0,2})N(.{3})([P|\d]\d{9}|NONREF)\s*(.+)?$/)
+    elsif @line.match(/^:61:(\d{6})(C|D)(\d+),(\d{0,2})N(.{3})([P|\d]\d{7,9}|NONREF)\s*(.+)?$/)
       sign = $2 == 'D' ? -1 : 1
       @transaction = MT940::Transaction.new(:bank_account => @bank_account, :amount => sign * ($3 + '.' + $4).to_f, :bank => @bank, :currency => @currency)
       @transaction.type = human_readable_type($5)


### PR DESCRIPTION
Some of my files contain bank account numbers that cannot be parsed. I suspect they SHOULD contain leading zeros to add up to 10 digits, but they don't. Limiting the acceptable number of digits seems to not break anything, so this accepts bank accounts numbers 7 or 8 digits long.
