### PR TITLE
add support for different sub-tags

### DIFF
--- a/lib/mt940_structured/file_content.rb
+++ b/lib/mt940_structured/file_content.rb
@@ -16,12 +16,12 @@ class MT940Structured::FileContent
     grouped_lines = []
     previous_tag = nil
     body_lines.each do |line|
-      mt940_line = line.match /^(:\d{2}[D|C|F]?:)/
+      mt940_line = line.match /^(:\d{2}[D|C|F|M]?:)/
       if mt940_line && previous_tag != $1
         previous_tag = $1
         grouped_lines << line
       else
-        next_line = if line.match /^(:\d{2}[D|C|F]?:)(.*)/
+        next_line = if line.match /^(:\d{2}[D|C|F|M]?:)(.*)/
                       $2
                     else
                       line

--- a/lib/mt940_structured/parsers/bank_statement_parser.rb
+++ b/lib/mt940_structured/parsers/bank_statement_parser.rb
@@ -8,7 +8,7 @@ module MT940Structured::Parsers
       @transaction_parsers = transaction_parsers
       @bank_statement = MT940::BankStatement.new([])
       lines.each do |line|
-        if line.match /^:(\d{2}(F|C)?):/
+        if line.match /^:(\d{2})(F|C|M)?:/
           parse_method = "parse_line_#{$1}".to_sym
           send(parse_method, line) if respond_to? parse_method
         else
@@ -32,7 +32,7 @@ module MT940Structured::Parsers
       end
     end
 
-    def parse_line_60F(line)
+    def parse_line_60(line)
       @bank_statement.previous_balance = parse_balance(line)
     end
 
@@ -51,7 +51,7 @@ module MT940Structured::Parsers
       @transaction_parser.enrich_transaction(@bank_statement.transactions.last, line)
     end
 
-    def parse_line_62F(line)
+    def parse_line_62(line)
       @bank_statement.new_balance = parse_balance(line)
     end
   end


### PR DESCRIPTION
Allow `bank_statement_parser` to parse tags regardless of their sub-type.

E.g. `:60M:` would be also processed by the `parse_line_60` method.
