### PR TITLE
allow to pass a custom divider that is used to join grouped lines

### DIFF
--- a/lib/mt940_structured/file_content.rb
+++ b/lib/mt940_structured/file_content.rb
@@ -3,8 +3,9 @@ class MT940Structured::FileContent
   R_EOF_ABN_AMRO = /^-$/
   R_EOF_TRIODOS = /^-$/
 
-  def initialize(raw_lines)
+  def initialize(raw_lines, join_lines_by = ' ')
     @raw_lines = raw_lines.map{|line|line.strip}
+    @join_lines_by = join_lines_by
   end
 
   def get_header
@@ -26,7 +27,7 @@ class MT940Structured::FileContent
                     else
                       line
                     end
-        grouped_lines[-1] = "#{grouped_lines.last} #{next_line}"
+        grouped_lines[-1] = [grouped_lines.last, @join_lines_by, next_line].join
       end
     end
     grouped_lines

--- a/lib/mt940_structured/parser.rb
+++ b/lib/mt940_structured/parser.rb
@@ -1,13 +1,18 @@
 module MT940Structured
   class Parser
-    def self.parse_mt940(path)
-      file_content = FileContent.new(File.open(path).readlines.map do |line|
-        line
-        .encode('UTF-8', 'binary', :invalid => :replace, :undef => :replace) # remove other obscure chars. god knows what people upload.
-        .gsub(/\u001A/, '') # remove eof chars in the middle of the string... yes it happens :-(
-      end)
+    def self.parse_mt940(path, join_lines_by = ' ')
+      file_content = FileContent.new(readfile(path), join_lines_by)
       grouped_lines = file_content.group_lines
       file_content.get_header.parser.transform(grouped_lines)
+    end
+
+    private
+    def self.readfile(path)
+      File.open(path).readlines.map do |line|
+        line
+          .encode('UTF-8', 'binary', :invalid => :replace, :undef => :replace) # remove other obscure chars. god knows what people upload.
+          .gsub(/\u001A/, '') # remove eof chars in the middle of the string... yes it happens :-(
+      end
     end
   end
 end

--- a/spec/mt940_structured/file_content_spec.rb
+++ b/spec/mt940_structured/file_content_spec.rb
@@ -66,4 +66,12 @@ describe MT940Structured::FileContent do
     its(:last) { should eq ":86:2121.21.211EUR" }
   end
 
+  context "custom grouping divider" do
+    let(:raw_lines) { [":20:940A121001", ":86:2121.21.211EUR", "belongs to first :86:", ":61:bla"] }
+    it "groups them using the custom divider" do
+      custom = MT940Structured::FileContent.new(raw_lines, "\n").group_lines
+      expect(custom[1]).to eq(":86:2121.21.211EUR\nbelongs to first :86:")
+    end
+  end
+
 end


### PR DESCRIPTION
Currently the grouped lines of tags are joined by an space character. In my implementation for "Deutsche Bank" I would need to join them without any divider or with an empty string.

This pull request adds a new parameter `join_lines_by` to `FileContent.new` that allows to specify a custom divider, e.g.

``` ruby
@bank_statements = MT940Structured::Parser.parse_mt940(@file_name, "")
```

or

``` ruby
@bank_statements = MT940Structured::Parser.parse_mt940(@file_name, "\n")
```
