### PR TITLE
parse the correct account number from deutsche bank files

### DIFF
--- a/lib/mt940_structured/parsers/bank_statement_parser.rb
+++ b/lib/mt940_structured/parsers/bank_statement_parser.rb
@@ -24,6 +24,9 @@ module MT940Structured::Parsers
           @bank_statement.bank_account_iban = line[4, 18]
           @bank_statement.bank_account = iban_to_account(@bank_statement.bank_account_iban)
           @is_structured_format = true
+        when /^:\d{2}:\d+\/(\d+)$/
+          @bank_statement.bank_account = $1.gsub(/^0+/, '')
+          @is_structured_format = true
         when /^:\d{2}:\D*(\d*)/
           @bank_statement.bank_account = $1.gsub(/\D/, '').gsub(/^0+/, '')
           @is_structured_format = false

--- a/spec/mt940_deutsche_bank_spec.rb
+++ b/spec/mt940_deutsche_bank_spec.rb
@@ -4,7 +4,7 @@ describe "Deutsche Bank" do
 
   before :all do
     @file_name       = File.dirname(__FILE__) + '/fixtures/deutsche_bank.txt'
-    @bank_statements = MT940Structured::Parser.parse_mt940(@file_name, "\n")["233025"]
+    @bank_statements = MT940Structured::Parser.parse_mt940(@file_name, "\n")["40069462"]
     @transactions    = @bank_statements.flat_map(&:transactions)
     @credit_transfer = @transactions[0]
     @direct_debit    = @transactions[1]
@@ -30,7 +30,7 @@ describe "Deutsche Bank" do
     end
 
     it 'have a bank_account' do
-      expect(@credit_transfer.bank_account).to eq '233025'
+      expect(@credit_transfer.bank_account).to eq '40069462'
     end
 
     it 'have an amount' do
@@ -79,7 +79,7 @@ describe "Deutsche Bank" do
     end
 
     it 'have a bank_account' do
-      expect(@direct_debit.bank_account).to eq '233025'
+      expect(@direct_debit.bank_account).to eq '40069462'
     end
 
     it 'have an amount' do


### PR DESCRIPTION
Hi, I've now used my extension for parsing files from deutsche bank the first time with real data and noticed that the account_no and bank_code in the bank-statement are swapped.

That's because the deutsche bank uses the following notation in `:25:` tag:

```
:25:(bank_code)/(account_no)
```

I updated my spec to look for the correct number and changed the implementation a bit. All other implementations aren't affected because this notation seems either to be a special case in germany or for the deutsche bank :grinning: 
